### PR TITLE
keep the central directory entries in same order as local headers

### DIFF
--- a/lib/zstream/zip.ex
+++ b/lib/zstream/zip.ex
@@ -76,7 +76,10 @@ defmodule Zstream.Zip do
     {compressed, state} = close_entry(state)
     :ok = :zlib.close(state.zlib_handle)
     state = put_in(state.zlib_handle, nil)
-    central_directory_headers = Enum.map(state.entries, &Protocol.central_directory_header/1)
+
+    central_directory_headers =
+      Enum.reverse(state.entries)
+      |> Enum.map(&Protocol.central_directory_header/1)
 
     zip64_end_of_central_directory_record =
       Protocol.zip64_end_of_central_directory_record(


### PR DESCRIPTION
> 4.4.1.3  The entries in the central directory MAY NOT necessarily
>      be in the same order that files appear in the .ZIP file.

Although zip specification allows to create central directory in
different order, Mac OSX Archive Utility seems to fail (This is a
guess, I couldn't find the exact reason, but keeping the same order
seems to make it happy)

fixes #5 