### PR TITLE
Prevent errors due to seconds == 60

### DIFF
--- a/lib/zstream/unzip.ex
+++ b/lib/zstream/unzip.ex
@@ -304,7 +304,7 @@ defmodule Zstream.Unzip do
         day,
         hour,
         minute,
-        Integer.mod(second * 2, 60)
+        min(second * 2, 59)
       )
 
     datetime

--- a/lib/zstream/unzip.ex
+++ b/lib/zstream/unzip.ex
@@ -304,7 +304,7 @@ defmodule Zstream.Unzip do
         day,
         hour,
         minute,
-        second * 2
+        Integer.mod(second * 2, 60)
       )
 
     datetime


### PR DESCRIPTION
I've been using zipfiles created by python code. Not sure if it's a python thing or a zipfile thing but I was getting errors when creating the file modification/creation dates. Bit of debugging showed that the problem was with the modification time seconds coming out at 60. `NaiveDateTime.new/6` correctly raised an error at that point.

This fix just removes the possibility of these seconds == 60 raising by wrapping the seconds between 0-59.

I'm not sure if this results in incorrect file timestamps though.