### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # The directory Mix downloads your dependencies sources to.
 /deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
+# Where third-party dependencies like ExDoc output generated docs.
 /doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
@@ -19,4 +19,8 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-.elixir_ls
+# Ignore package tarball (built via "mix hex.build").
+zstream-*.tar
+
+# Temporary files for e.g. tests.
+/tmp

--- a/README.md
+++ b/README.md
@@ -1,12 +1,30 @@
 # Zstream
 
-[![Hex.pm](https://img.shields.io/hexpm/v/zstream.svg)](https://hex.pm/packages/zstream)
+[![CI](https://github.com/ananthakumaran/zstream/workflows/.github/workflows/ci.yml/badge.svg)](https://github.com/ananthakumaran/zstream/actions?query=workflow%3A.github%2Fworkflows%2Fci.yml)
+[![Module Version](https://img.shields.io/hexpm/v/zstream.svg)](https://hex.pm/packages/zstream)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/zstream/)
+[![Total Download](https://img.shields.io/hexpm/dt/zstream.svg)](https://hex.pm/packages/zstream)
+[![License](https://img.shields.io/hexpm/l/zstream.svg)](https://github.com/ananthakumaran/zstream/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/ananthakumaran/zstream.svg)](https://github.com/ananthakumaran/zstream/commits/master)
 
-An elixir library to read and write ZIP file in a streaming
+An Elixir library to read and write ZIP file in a streaming
 fashion. It could consume data from any stream and write to any stream
-with constant memory overhead
+with constant memory overhead.
 
-## Example
+## Installation
+
+The package can be installed by adding `:zstream` to your list of dependencies
+in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:zstream, "~> 0.5.0"}
+  ]
+end
+```
+
+## Examples
 
 ```elixir
 Zstream.zip([
@@ -40,4 +58,8 @@ end)
 * compression (deflate, stored)
 * zip64
 
-see [documenation](https://hexdocs.pm/zstream/) for more information.
+## License
+
+Copyright (c) 2017 Anantha Kumaran
+
+This library is MIT licensed. See the [LICENSE](https://github.com/ananthakumaran/zstream/blob/master/LICENSE) for details.

--- a/lib/zstream.ex
+++ b/lib/zstream.ex
@@ -1,27 +1,6 @@
 defmodule Zstream do
   @moduledoc """
-  Module for reading and writing ZIP file stream
-
-  ## Example
-
-  ```
-  Zstream.zip([
-    Zstream.entry("report.csv", Stream.map(records, &CSV.dump/1)),
-    Zstream.entry("catfilm.mp4", File.stream!("/catfilm.mp4", [], 512), coder: Zstream.Coder.Stored)
-  ])
-  |> Stream.into(File.stream!("/archive.zip"))
-  |> Stream.run
-  ```
-
-  ```
-  File.stream!("archive.zip", [], 512)
-  |> Zstream.unzip()
-  |> Enum.reduce(%{}, fn
-    {:entry, %Zstream.Entry{name: file_name} = entry}, state -> state
-    {:data, data}, state -> state
-    {:data, :eof}, state -> state
-  end)
-  ```
+  Module for reading and writing ZIP file stream.
   """
 
   defmodule Entry do
@@ -38,58 +17,58 @@ defmodule Zstream do
   @opaque entry :: map
 
   @doc """
-  Creates a ZIP file entry with the given `name`
+  Creates a ZIP file entry with the given `name`.
 
   The `enum` could be either lazy `Stream` or `List`. The elements in `enum`
   should be of type `iodata`
 
   ## Options
 
-  * `:coder` (module | {module, list}) - The compressor that should be
-    used to encode the data. Available options are
+    * `:coder` (module | {module, list}) - The compressor that should be
+      used to encode the data. Available options are:
 
-    `Zstream.Coder.Deflate` - use deflate compression
+        - `Zstream.Coder.Deflate` - use deflate compression
 
-    `Zstream.Coder.Stored` - store without any compression
+        - `Zstream.Coder.Stored` - store without any compression
 
-     Defaults to `Zstream.Coder.Deflate`
+        - Defaults to `Zstream.Coder.Deflate`
 
-  * `:encryption_coder` ({module, keyword}) - The encryption module that should be
-    used to encrypt the data. Available options are
+    * `:encryption_coder` ({module, keyword}) - The encryption module that should be
+      used to encrypt the data. Available options are:
 
-    `Zstream.EncryptionCoder.Traditional` - use tranditional zip
-    encryption scheme. `:password` key should be present in the
-    options. Example `{Zstream.EncryptionCoder.Traditional, password:
-    "secret"}`
+        - `Zstream.EncryptionCoder.Traditional` - use tranditional zip
+        encryption scheme. `:password` key should be present in the
+        options. Example `{Zstream.EncryptionCoder.Traditional, password:
+        "secret"}`
 
-    `Zstream.EncryptionCoder.None` - no encryption
+        - `Zstream.EncryptionCoder.None` - no encryption
 
-     Defaults to `Zstream.EncryptionCoder.None`
+        - Defaults to `Zstream.EncryptionCoder.None`
 
 
-  * `:mtime` (DateTime) - File last modication time. Defaults to system local time.
+    * `:mtime` (DateTime) - File last modication time. Defaults to system local time.
   """
   @spec entry(String.t(), Enumerable.t(), Keyword.t()) :: entry
   defdelegate entry(name, enum, options \\ []), to: Zstream.Zip
 
   @doc """
-  Creates a ZIP file stream
+  Creates a ZIP file stream.
 
-  entries are consumed one by one in the given order
+  Entries are consumed one by one in the given order.
 
   ## Options
 
-  * `:zip64` (boolean) - If set to `true` zip64 format is used. Zip64
-    can support files more than 4 GB in size, but not all the unzip
-    programs support this format. Defaults to `false`
+    * `:zip64` (boolean) - If set to `true` zip64 format is used. Zip64
+      can support files more than 4 GB in size, but not all the unzip
+      programs support this format. Defaults to `false`.
   """
   @spec zip([entry], Keyword.t()) :: Enumerable.t()
   defdelegate zip(entries, options \\ []), to: Zstream.Zip
 
   @doc """
-  Unzips file stream
+  Unzips file stream.
 
-  returns a new stream which emits the following tuples for each zip entry
+  Returns a new stream which emits the following tuples for each zip entry.
 
   {`:entry`, `t:Zstream.Entry.t/0`} - Indicates a new file entry.
 
@@ -102,11 +81,11 @@ defmodule Zstream do
   allows the writer to zip streams with unknown size. But this
   prevents the reader from unzipping the file in a streaming fashion,
   because to find the file size one has to go to the end of the
-  stream. Ironcially, if you use Zstream to zip a file, the same file
+  stream. Ironically, if you use Zstream to zip a file, the same file
   can't be unzipped using Zstream.
 
-  * doesn't support file which uses data descriptor header
-  * doesn't support encrypted file
+    * Doesn't support file which uses data descriptor header.
+    * Doesn't support encrypted file.
   """
   defdelegate unzip(stream), to: Zstream.Unzip
 end

--- a/lib/zstream/coder/deflate.ex
+++ b/lib/zstream/coder/deflate.ex
@@ -1,8 +1,9 @@
 defmodule Zstream.Coder.Deflate do
-  @behaviour Zstream.Coder
   @moduledoc """
-  Implements the Deflate coder
+  Implements the Deflate coder.
   """
+
+  @behaviour Zstream.Coder
 
   def init(_opts) do
     z = :zlib.open()

--- a/lib/zstream/coder/stored.ex
+++ b/lib/zstream/coder/stored.ex
@@ -1,8 +1,9 @@
 defmodule Zstream.Coder.Stored do
-  @behaviour Zstream.Coder
   @moduledoc """
-  Implements the Stored(uncompressed) coder
+  Implements the Stored(uncompressed) coder.
   """
+
+  @behaviour Zstream.Coder
 
   def init(_opts) do
     nil

--- a/lib/zstream/encryption_coder/none.ex
+++ b/lib/zstream/encryption_coder/none.ex
@@ -1,8 +1,10 @@
 defmodule Zstream.EncryptionCoder.None do
-  @behaviour Zstream.EncryptionCoder
   @moduledoc """
-  Noop encryption
+  Noop encryption.
   """
+
+  @behaviour Zstream.EncryptionCoder
+
   def init(_opts) do
     nil
   end

--- a/lib/zstream/encryption_coder/traditional.ex
+++ b/lib/zstream/encryption_coder/traditional.ex
@@ -1,8 +1,10 @@
 defmodule Zstream.EncryptionCoder.Traditional do
-  @behaviour Zstream.EncryptionCoder
   @moduledoc """
-  Implements the trandition encryption
+  Implements the tradition encryption.
   """
+
+  @behaviour Zstream.EncryptionCoder
+
   use Bitwise
 
   defmodule State do

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,14 @@
 defmodule Zstream.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/ananthakumaran/zstream"
   @version "0.5.2"
 
   def project do
     [
       app: :zstream,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       description: "Streaming zip file writer and reader",
       package: package(),
@@ -28,25 +29,25 @@ defmodule Zstream.Mixfile do
 
   defp deps do
     [
-      {:temp, "~> 0.4", only: :test},
-      {:ex_doc, "~> 0.19", only: :dev}
+      {:temp, "~> 0.4", only: :test, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 
   defp package do
     %{
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/ananthakumaran/zstream"},
-      maintainers: ["ananthakumaran@gmail.com"]
+      links: %{"GitHub" => @source_url},
+      maintainers: ["Anantha Kumaran <ananthakumaran@gmail.com>"]
     }
   end
 
   defp docs do
     [
-      source_url: "https://github.com/ananthakumaran/zstream",
-      source_ref: "v#{@version}",
-      main: Zstream,
-      extras: ["README.md"]
+      extras: ["README.md"],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}"
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
 %{
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},
-  "temp": {:hex, :temp, "0.4.3", "b641c3ce46094839bff110fdb64162536d640d9d47ca2c37add9104a2fa3bd81", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  "temp": {:hex, :temp, "0.4.3", "b641c3ce46094839bff110fdb64162536d640d9d47ca2c37add9104a2fa3bd81", [:mix], [], "hexpm", "d7535439aeb967da5c37c96215fc204d77ec578b5cfc1c7948667052bf075ab9"},
 }


### PR DESCRIPTION
Besides other fixes, this commit allows the generated HTML doc for
HexDocs.pm will become the main doc source for this Elixir module.

List of changes:
* Use common source url
* Set readme as main html doc
* Use and set ex_doc to latest version
* Add license section
* Update gitignore
* Add code formatter
* Fix markdown and typos
* Badges and more badges!
* Tally minimum Elixir requirement version with CI

Screenshot:

![Screenshot-20210216194620-2672x1460](https://user-images.githubusercontent.com/134518/108058975-c4d72380-708f-11eb-9394-c170ee40529b.png)
