### PR TITLE
Remove deprecation warnings in Elixir 1.12

### DIFF
--- a/lib/zstream/encryption_coder/traditional.ex
+++ b/lib/zstream/encryption_coder/traditional.ex
@@ -52,8 +52,8 @@ defmodule Zstream.EncryptionCoder.Traditional do
   defp encrypt(state, <<char::binary-size(1)>> <> rest, encrypted) do
     <<byte::integer-size(8)>> = char
     temp = (state.key2 ||| 2) &&& 0x0000FFFF
-    temp = (temp * (temp ^^^ 1)) >>> 8 &&& 0x000000FF
-    cipher = <<byte ^^^ temp::integer-size(8)>>
+    temp = (temp * Bitwise.bxor(temp, 1)) >>> 8 &&& 0x000000FF
+    cipher = << Bitwise.bxor(byte, temp)::integer-size(8)>>
     state = update_keys(state, <<byte::integer-size(8)>>)
     encrypt(state, rest, [cipher | encrypted])
   end
@@ -79,7 +79,7 @@ defmodule Zstream.EncryptionCoder.Traditional do
   end
 
   defp crc32(current, data) do
-    :erlang.crc32(current ^^^ 0xFFFFFFFF, data) ^^^ 0xFFFFFFFF
+    Bitwise.bxor(:erlang.crc32(Bitwise.bxor(current, 0xFFFFFFFF), data), 0xFFFFFFFF)
   end
 
   defp dos_time(t) do

--- a/lib/zstream/zip.ex
+++ b/lib/zstream/zip.ex
@@ -129,7 +129,7 @@ defmodule Zstream.Zip do
 
     state = update_in(state.current, &Map.merge(&1, header))
     state = put_in(state.current.options, header.options)
-    state = put_in(state.current.crc, :zlib.crc32(state.zlib_handle, <<>>))
+    state = put_in(state.current.crc, :erlang.crc32(<<>>))
     state = put_in(state.current.local_file_header_offset, state.offset)
 
     local_file_header =
@@ -153,7 +153,7 @@ defmodule Zstream.Zip do
     state = put_in(state.coder_state, coder_state)
     state = put_in(state.encryption_coder_state, encryption_coder_state)
     state = update_in(state.current.c_size, &(&1 + c_size))
-    state = update_in(state.current.crc, &:zlib.crc32(state.zlib_handle, &1, chunk))
+    state = update_in(state.current.crc, &:erlang.crc32(&1, chunk))
     state = update_in(state.current.size, &(&1 + IO.iodata_length(chunk)))
     state = update_in(state.offset, &(&1 + c_size))
 


### PR DESCRIPTION
Elixir's bitwise binary XOR operator ^^^ was deprecated in favor of
the explicit Bitwise.bxor/2.

Erlang's zlib:crc32/2 and zlib:crc32/3 were deprecated in favor of
erlang:crc32/1 and erlang:crc32/2