### PR TITLE
Fix deprecations with Elixir 1.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
             check_warnings: true
             check_format: true
             dialyzer: true
+          - elixir: 1.14.0
+            otp: 25.0
+            check_warnings: true
+            check_format: true
+            dialyzer: true
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-elixir@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.0-otp-25
-erlang 25.0.4
+elixir 1.11.4-otp-23
+erlang 23.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.0-otp-23
-erlang 23.1
+elixir 1.14.0-otp-25
+erlang 25.0.4

--- a/lib/zstream/encryption_coder/traditional.ex
+++ b/lib/zstream/encryption_coder/traditional.ex
@@ -5,7 +5,7 @@ defmodule Zstream.EncryptionCoder.Traditional do
 
   @behaviour Zstream.EncryptionCoder
 
-  use Bitwise
+  import Bitwise
 
   defmodule State do
     @moduledoc false

--- a/lib/zstream/protocol.ex
+++ b/lib/zstream/protocol.ex
@@ -1,7 +1,7 @@
 defmodule Zstream.Protocol do
   @moduledoc false
 
-  use Bitwise
+  import Bitwise
   alias Zstream.Zip.Extra
 
   # Specification is available at

--- a/lib/zstream/unzip.ex
+++ b/lib/zstream/unzip.ex
@@ -7,7 +7,7 @@ defmodule Zstream.Unzip do
     defexception [:message]
   end
 
-  use Bitwise
+  import Bitwise
 
   defmodule LocalHeader do
     @moduledoc false

--- a/lib/zstream/unzip/extra.ex
+++ b/lib/zstream/unzip/extra.ex
@@ -1,6 +1,6 @@
 defmodule Zstream.Unzip.Extra do
   @moduledoc false
-  use Bitwise
+  import Bitwise
 
   defmodule Unknown do
     @type t :: %__MODULE__{

--- a/lib/zstream/zip/extra.ex
+++ b/lib/zstream/zip/extra.ex
@@ -1,6 +1,5 @@
 defmodule Zstream.Zip.Extra do
   @moduledoc false
-  use Bitwise
 
   #    -Zip64 Extended Information Extra Field (0x0001):
 


### PR DESCRIPTION
Elixir 1.14 deprecates `use Bitwise` in favour of `import Bitwise`. This PR fixes those and updates the tool-versions file.

This is not backwards compatible with previous versions, so it probably makes sense to make this a new major version release and to have the older releases to support older versions of Elixir.