### PR TITLE
docs: add warning about large chunk allocations in traditional encryption

### DIFF
--- a/lib/zstream/encryption_coder/traditional.ex
+++ b/lib/zstream/encryption_coder/traditional.ex
@@ -1,6 +1,11 @@
 defmodule Zstream.EncryptionCoder.Traditional do
   @moduledoc """
-  Implements the tradition encryption.
+  Implements traditional encryption using byte-by-byte processing.
+
+  #### Notice {: .warning}
+
+  Processing a single large chunk can lead to significant memory allocation due to recursive handling of each byte.
+  To improve performance, split your data into smaller chunks.
   """
 
   @behaviour Zstream.EncryptionCoder


### PR DESCRIPTION
Run this script and use `observer` to monitor the allocation behavior:

```
test_data = 2 * 1024 * 1024 |> :crypto.strong_rand_bytes() |> List.wrap

Zstream.zip([Zstream.entry("test.csv", test_data)], encryption_coder: {Zstream.EncryptionCoder.Traditional, password: "123456"})
|> Stream.into(File.stream!("test.zip"))
|> Stream.run
```