### PR TITLE
zip64 values in central directory should be ceiled only if they exceed allowed int size

### DIFF
--- a/lib/zstream/protocol.ex
+++ b/lib/zstream/protocol.ex
@@ -163,11 +163,11 @@ defmodule Zstream.Protocol do
       # number of the disk with the start of the central directory
       zip64?(options, 0, 0xFFFF)::little-size(16),
       # total number of entries in the central directory on this disk
-      zip64?(options, entries_count, 0xFFFF)::little-size(16),
+      ceil_zip64?(options, entries_count, 0xFFFF)::little-size(16),
       # total number of entries in the central directory
-      zip64?(options, entries_count, 0xFFFF)::little-size(16),
+      ceil_zip64?(options, entries_count, 0xFFFF)::little-size(16),
       # size of the central directory
-      zip64?(options, size, 0xFFFFFFFF)::little-size(32),
+      ceil_zip64?(options, size, 0xFFFFFFFF)::little-size(32),
       # offset of start of central directory with respect to the starting disk number
       zip64?(options, offset, 0xFFFFFFFF)::little-size(32),
       # .ZIP file comment length
@@ -207,6 +207,14 @@ defmodule Zstream.Protocol do
   defp zip64?(options, normal, zip64) do
     if Keyword.fetch!(options, :zip64) do
       zip64
+    else
+      normal
+    end
+  end
+
+  defp ceil_zip64?(options, normal, max_value) do
+    if Keyword.fetch!(options, :zip64) && normal > max_value do
+      max_value
     else
       normal
     end

--- a/lib/zstream/protocol.ex
+++ b/lib/zstream/protocol.ex
@@ -154,22 +154,22 @@ defmodule Zstream.Protocol do
     end
   end
 
-  def end_of_central_directory(offset, size, entries_count, options) do
+  def end_of_central_directory(offset, size, entries_count) do
     <<
       # end of central dir signature
       0x06054B50::little-size(32),
       # number of this disk
-      zip64?(options, 0, 0xFFFF)::little-size(16),
+      0::little-size(16),
       # number of the disk with the start of the central directory
-      zip64?(options, 0, 0xFFFF)::little-size(16),
+      0::little-size(16),
       # total number of entries in the central directory on this disk
-      ceil_zip64?(options, entries_count, 0xFFFF)::little-size(16),
+      Enum.min([entries_count, 0xFFFF])::little-size(16),
       # total number of entries in the central directory
-      ceil_zip64?(options, entries_count, 0xFFFF)::little-size(16),
+      Enum.min([entries_count, 0xFFFF])::little-size(16),
       # size of the central directory
-      ceil_zip64?(options, size, 0xFFFFFFFF)::little-size(32),
+      Enum.min([size, 0xFFFFFFFF])::little-size(32),
       # offset of start of central directory with respect to the starting disk number
-      zip64?(options, offset, 0xFFFFFFFF)::little-size(32),
+      Enum.min([offset, 0xFFFFFFFF])::little-size(32),
       # .ZIP file comment length
       byte_size(@comment)::little-size(16),
       @comment
@@ -207,14 +207,6 @@ defmodule Zstream.Protocol do
   defp zip64?(options, normal, zip64) do
     if Keyword.fetch!(options, :zip64) do
       zip64
-    else
-      normal
-    end
-  end
-
-  defp ceil_zip64?(options, normal, max_value) do
-    if Keyword.fetch!(options, :zip64) && normal > max_value do
-      max_value
     else
       normal
     end

--- a/lib/zstream/zip.ex
+++ b/lib/zstream/zip.ex
@@ -99,8 +99,7 @@ defmodule Zstream.Zip do
       Protocol.end_of_central_directory(
         state.offset,
         IO.iodata_length(central_directory_headers),
-        length(state.entries),
-        global_options
+        length(state.entries)
       )
 
     {[


### PR DESCRIPTION
Currently for zip64 files, the values that might overflow (e.g. size of central directory) will always be set to their max value. Some archiver utilities, such as BetterZip on Mac, don't seem to like it and instead expect the correct value to be set.

The change I'm proposing will write correct number of entries and correct directory size in case these values are smaller than their int limit.

This might also be causing #18, but I don't have a Xiaomi phone to test it.

I'll have to do a few more tests, such as zipping files larger than 4GB, zipping more than 65k files (which hits entry limit), but I would appreciate any feedback while I'm working on it.