### PR TITLE
Add WinZip AES encryption support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+      - name: Install 7zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y 7zip
       - run: mix deps.get
       - run: mix format --check-formatted
         if: ${{ matrix.check_format }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ end)
 ### zip
 
 * compression (deflate, stored)
-* encryption (traditional)
+* encryption (traditional, [WinZip AES](https://www.winzip.com/en/support/aes-encryption/))
 * zip64
 
 ### unzip

--- a/lib/zstream.ex
+++ b/lib/zstream.ex
@@ -44,7 +44,7 @@ defmodule Zstream do
         - `Zstream.EncryptionCoder.AES` - use AES encryption (128, 192, or 256-bit).
         `:password` key should be present in the options. Supports both AE-1 and AE-2
         formats. Additional options: `:key_size` (128, 192, or 256, defaults to 256),
-        `:ae_version` (1 or 2, defaults to 2). Example `{Zstream.EncryptionCoder.AES,
+        `:ae_version` (1 or 2, defaults to 1). Example `{Zstream.EncryptionCoder.AES,
         password: "secret", key_size: 256, ae_version: 1}`
 
         - `Zstream.EncryptionCoder.None` - no encryption

--- a/lib/zstream.ex
+++ b/lib/zstream.ex
@@ -41,6 +41,12 @@ defmodule Zstream do
         options. Example `{Zstream.EncryptionCoder.Traditional, password:
         "secret"}`
 
+        - `Zstream.EncryptionCoder.AES` - use AES encryption (128, 192, or 256-bit).
+        `:password` key should be present in the options. Supports both AE-1 and AE-2
+        formats. Additional options: `:key_size` (128, 192, or 256, defaults to 256),
+        `:ae_version` (1 or 2, defaults to 2). Example `{Zstream.EncryptionCoder.AES,
+        password: "secret", key_size: 256, ae_version: 2}`
+
         - `Zstream.EncryptionCoder.None` - no encryption
 
         - Defaults to `Zstream.EncryptionCoder.None`

--- a/lib/zstream.ex
+++ b/lib/zstream.ex
@@ -45,7 +45,7 @@ defmodule Zstream do
         `:password` key should be present in the options. Supports both AE-1 and AE-2
         formats. Additional options: `:key_size` (128, 192, or 256, defaults to 256),
         `:ae_version` (1 or 2, defaults to 2). Example `{Zstream.EncryptionCoder.AES,
-        password: "secret", key_size: 256, ae_version: 2}`
+        password: "secret", key_size: 256, ae_version: 1}`
 
         - `Zstream.EncryptionCoder.None` - no encryption
 

--- a/lib/zstream/encryption_coder.ex
+++ b/lib/zstream/encryption_coder.ex
@@ -8,4 +8,19 @@ defmodule Zstream.EncryptionCoder do
   @callback close(state :: term) :: iodata
 
   @callback general_purpose_flag() :: integer
+
+  @optional_callbacks [
+    compression_method: 0,
+    extra_field_data: 1,
+    version_needed_to_extract: 0,
+    crc_exposed?: 1
+  ]
+
+  @callback compression_method() :: integer
+
+  @callback extra_field_data(options :: Keyword.t()) :: binary
+
+  @callback version_needed_to_extract() :: integer
+
+  @callback crc_exposed?(options :: Keyword.t()) :: boolean
 end

--- a/lib/zstream/encryption_coder/aes.ex
+++ b/lib/zstream/encryption_coder/aes.ex
@@ -184,6 +184,7 @@ defmodule Zstream.EncryptionCoder.AES do
     >>
   end
 
+  # https://github.com/zlib-ng/minizip-ng/blob/636cba8643/doc/zip/appnote.iz.txt#L386
   @impl true
   def version_needed_to_extract, do: 51
 

--- a/lib/zstream/encryption_coder/aes.ex
+++ b/lib/zstream/encryption_coder/aes.ex
@@ -18,7 +18,7 @@ defmodule Zstream.EncryptionCoder.AES do
   # https://www.winzip.com/en/support/aes-encryption/#key-generation
   @pbkdf2_iterations 1000
   # https://www.winzip.com/en/support/aes-encryption/#salt
-  @pbkdf2_salt_length 16
+  @pbkdf2_salt_lengths %{128 => 8, 192 => 12, 256 => 16}
   # https://www.winzip.com/en/support/aes-encryption/#pwd-verify
   @password_verify_length 2
 
@@ -53,7 +53,7 @@ defmodule Zstream.EncryptionCoder.AES do
     end
 
     aes_key_length = @aes_key_sizes[key_size]
-    salt = :crypto.strong_rand_bytes(@pbkdf2_salt_length)
+    salt = :crypto.strong_rand_bytes(@pbkdf2_salt_lengths[key_size])
 
     <<
       encryption_key::binary-size(aes_key_length),

--- a/lib/zstream/encryption_coder/aes.ex
+++ b/lib/zstream/encryption_coder/aes.ex
@@ -143,7 +143,7 @@ defmodule Zstream.EncryptionCoder.AES do
 
     # https://www.winzip.com/win/en/aes_info.html#auth-faq
     auth_code = binary_part(:crypto.mac_final(final_state.mac_state), 0, 10)
-    _should_be_empty = :crypto.crypto_final(final_state.crypto_state)
+    <<>> = :crypto.crypto_final(final_state.crypto_state)
 
     final_encrypted <> auth_code
   end

--- a/lib/zstream/encryption_coder/aes.ex
+++ b/lib/zstream/encryption_coder/aes.ex
@@ -145,7 +145,7 @@ defmodule Zstream.EncryptionCoder.AES do
     auth_code = binary_part(:crypto.mac_final(final_state.mac_state), 0, 10)
     <<>> = :crypto.crypto_final(final_state.crypto_state)
 
-    final_encrypted <> auth_code
+    [final_encrypted, auth_code]
   end
 
   # https://www.winzip.com/en/support/aes-encryption/#comp-method

--- a/lib/zstream/encryption_coder/aes.ex
+++ b/lib/zstream/encryption_coder/aes.ex
@@ -1,0 +1,196 @@
+defmodule Zstream.EncryptionCoder.AES do
+  @moduledoc """
+  Implements AES encryption (128, 192, 256) as described in https://www.winzip.com/en/support/aes-encryption
+
+  Supports both AE-1 and AE-2 formats:
+  - AE-1: Exposes the CRC-32 in the zip file
+  - AE-2: Does not expose the CRC-32 in the zip file (more secure, recommended)
+
+  ## Options
+
+    * `:key_size` - The AES key size in bits. Valid values are 128, 192, or 256. Defaults to 256.
+    * `:ae_version` - The AES encryption format version. Valid values are 1 or 2. Defaults to 2.
+  """
+  @behaviour Zstream.EncryptionCoder
+
+  @aes_block_size 16
+
+  # https://www.winzip.com/en/support/aes-encryption/#key-generation
+  @pbkdf2_iterations 1000
+  # https://www.winzip.com/en/support/aes-encryption/#salt
+  @pbkdf2_salt_length 16
+  # https://www.winzip.com/en/support/aes-encryption/#pwd-verify
+  @password_verify_length 2
+
+  # AES key sizes in bytes
+  @aes_key_sizes %{128 => 16, 192 => 24, 256 => 32}
+  # AES mode indicators for extra field
+  @aes_mode_indicators %{128 => 0x01, 192 => 0x02, 256 => 0x03}
+  # AES algorithm names for :crypto
+  @aes_algorithms %{128 => :aes_128_ecb, 192 => :aes_192_ecb, 256 => :aes_256_ecb}
+
+  defmodule State do
+    defstruct mac_state: nil,
+              crypto_state: nil,
+              encrypted_file_header: <<>>,
+              counter: 1,
+              buffer: <<>>,
+              key_size: 256
+  end
+
+  @impl true
+  def init(opts) do
+    password = Keyword.fetch!(opts, :password)
+    key_size = Keyword.get(opts, :key_size, 256)
+    ae_version = Keyword.get(opts, :ae_version, 2)
+
+    if key_size not in [128, 192, 256] do
+      raise ArgumentError, "Invalid key_size: #{key_size}. Must be 128, 192, or 256."
+    end
+
+    if ae_version not in [1, 2] do
+      raise ArgumentError, "Invalid ae_version: #{ae_version}. Must be 1 or 2."
+    end
+
+    aes_key_length = @aes_key_sizes[key_size]
+    salt = :crypto.strong_rand_bytes(@pbkdf2_salt_length)
+
+    <<
+      encryption_key::binary-size(aes_key_length),
+      hmac_key::binary-size(aes_key_length),
+      password_verify::binary-size(@password_verify_length)
+    >> =
+      :crypto.pbkdf2_hmac(
+        :sha,
+        password,
+        salt,
+        @pbkdf2_iterations,
+        aes_key_length + aes_key_length + @password_verify_length
+      )
+
+    %State{
+      encrypted_file_header: salt <> password_verify,
+      crypto_state: :crypto.crypto_init(@aes_algorithms[key_size], encryption_key, true),
+      mac_state: :crypto.mac_init(:hmac, :sha, hmac_key),
+      counter: 1,
+      key_size: key_size
+    }
+  end
+
+  @impl true
+  def encode(chunk, state) do
+    if state.encrypted_file_header != <<>> do
+      {encrypted, updated_state} = encrypt_chunk(chunk, %{state | encrypted_file_header: <<>>})
+      {[state.encrypted_file_header, encrypted], updated_state}
+    else
+      encrypt_chunk(chunk, state)
+    end
+  end
+
+  defp encrypt_chunk(
+         chunk,
+         %State{buffer: buffer, counter: counter, crypto_state: crypto_state} = state
+       ) do
+    input = IO.iodata_to_binary([buffer, chunk])
+    input_size = byte_size(input)
+
+    if input_size < @aes_block_size do
+      {<<>>, %{state | buffer: input}}
+    else
+      block_count = div(input_size, @aes_block_size)
+      blocks = Enum.map(counter..(counter + block_count - 1), &<<&1::unsigned-little-128>>)
+      plaintext_size = block_count * @aes_block_size
+      <<plaintext::binary-size(plaintext_size), new_buffer::binary>> = input
+      cipher = :crypto.exor(plaintext, :crypto.crypto_update(crypto_state, blocks))
+
+      {
+        cipher,
+        %{
+          state
+          | mac_state: :crypto.mac_update(state.mac_state, cipher),
+            counter: counter + block_count,
+            buffer: new_buffer
+        }
+      }
+    end
+  end
+
+  @impl true
+  def close(%State{buffer: buffer, counter: counter, crypto_state: crypto_state} = state) do
+    buffer_size = byte_size(buffer)
+
+    {final_encrypted, final_state} =
+      if buffer_size > 0 do
+        last_block = <<counter::unsigned-little-128>>
+
+        cipher =
+          :crypto.exor(
+            buffer,
+            binary_part(:crypto.crypto_update(crypto_state, last_block), 0, buffer_size)
+          )
+
+        final_state = %{
+          state
+          | mac_state: :crypto.mac_update(state.mac_state, cipher),
+            counter: counter + 1,
+            buffer: <<>>
+        }
+
+        {cipher, final_state}
+      else
+        {<<>>, state}
+      end
+
+    # https://www.winzip.com/win/en/aes_info.html#auth-faq
+    auth_code = binary_part(:crypto.mac_final(final_state.mac_state), 0, 10)
+    _should_be_empty = :crypto.crypto_final(final_state.crypto_state)
+
+    final_encrypted <> auth_code
+  end
+
+  # https://www.winzip.com/en/support/aes-encryption/#comp-method
+  @impl true
+  def general_purpose_flag do
+    # which means encrypted (0x0001)
+    0x0001
+  end
+
+  # https://www.winzip.com/en/support/aes-encryption/#comp-method
+  # a compression method of 99 is used to indicate the presence of an AES-encrypted file
+  @impl true
+  def compression_method, do: 99
+
+  # https://www.winzip.com/en/support/aes-encryption/#extra-data
+  @impl true
+  def extra_field_data(options) do
+    {coder, _options} = Keyword.fetch!(options, :coder)
+    {_encryption_coder, encryption_options} = Keyword.fetch!(options, :encryption_coder)
+    key_size = Keyword.get(encryption_options, :key_size, 256)
+    ae_version = Keyword.get(encryption_options, :ae_version, 2)
+
+    <<
+      # Extra field header ID
+      0x9901::little-size(16),
+      # Data size
+      7::little-size(16),
+      # Integer version number specific to the zip vendor, 0x0001 ae-1, 0x0002 ae-2
+      ae_version::little-size(16),
+      # 2-character vendor ID
+      "AE"::binary,
+      # Integer mode value indicating AES encryption strength
+      @aes_mode_indicators[key_size]::little-size(8),
+      # Actual compression method used (8=deflate, 0=stored)
+      coder.compression_method()::little-size(16)
+    >>
+  end
+
+  @impl true
+  def version_needed_to_extract, do: 51
+
+  @impl true
+  def crc_exposed?(options) do
+    {_encryption_coder, encryption_options} = Keyword.fetch!(options, :encryption_coder)
+    ae_version = Keyword.get(encryption_options, :ae_version, 2)
+    ae_version == 1
+  end
+end

--- a/lib/zstream/encryption_coder/aes.ex
+++ b/lib/zstream/encryption_coder/aes.ex
@@ -3,13 +3,13 @@ defmodule Zstream.EncryptionCoder.AES do
   Implements AES encryption (128, 192, 256) as described in https://www.winzip.com/en/support/aes-encryption
 
   Supports both AE-1 and AE-2 formats:
-  - AE-1: Exposes the CRC-32 in the zip file
-  - AE-2: Does not expose the CRC-32 in the zip file (more secure, recommended)
+  - AE-1: Exposes the CRC-32 in the zip file, WinZip itself encrypts most files using the AE-1 format
+  - AE-2: Does not expose the CRC-32 in the zip file
 
   ## Options
 
     * `:key_size` - The AES key size in bits. Valid values are 128, 192, or 256. Defaults to 256.
-    * `:ae_version` - The AES encryption format version. Valid values are 1 or 2. Defaults to 2.
+    * `:ae_version` - The AES encryption format version. Valid values are 1 or 2. Defaults to 1.
   """
   @behaviour Zstream.EncryptionCoder
 
@@ -42,7 +42,7 @@ defmodule Zstream.EncryptionCoder.AES do
   def init(opts) do
     password = Keyword.fetch!(opts, :password)
     key_size = Keyword.get(opts, :key_size, 256)
-    ae_version = Keyword.get(opts, :ae_version, 2)
+    ae_version = Keyword.get(opts, :ae_version, 1)
 
     if key_size not in [128, 192, 256] do
       raise ArgumentError, "Invalid key_size: #{key_size}. Must be 128, 192, or 256."
@@ -166,7 +166,7 @@ defmodule Zstream.EncryptionCoder.AES do
     {coder, _options} = Keyword.fetch!(options, :coder)
     {_encryption_coder, encryption_options} = Keyword.fetch!(options, :encryption_coder)
     key_size = Keyword.get(encryption_options, :key_size, 256)
-    ae_version = Keyword.get(encryption_options, :ae_version, 2)
+    ae_version = Keyword.get(encryption_options, :ae_version, 1)
 
     <<
       # Extra field header ID
@@ -191,7 +191,7 @@ defmodule Zstream.EncryptionCoder.AES do
   @impl true
   def crc_exposed?(options) do
     {_encryption_coder, encryption_options} = Keyword.fetch!(options, :encryption_coder)
-    ae_version = Keyword.get(encryption_options, :ae_version, 2)
+    ae_version = Keyword.get(encryption_options, :ae_version, 1)
     ae_version == 1
   end
 end

--- a/lib/zstream/protocol.ex
+++ b/lib/zstream/protocol.ex
@@ -21,11 +21,11 @@ defmodule Zstream.Protocol do
 
     encryption_coder = get_encryption_coder(options)
 
-    encryption_extra_field =
+    final_extra_field =
       if encryption_coder && function_exported?(encryption_coder, :extra_field_data, 1) do
-        encryption_coder.extra_field_data(options)
+        [extra_field, encryption_coder.extra_field_data(options)]
       else
-        <<>>
+        extra_field
       end
 
     version_needed_to_extract =
@@ -57,10 +57,10 @@ defmodule Zstream.Protocol do
         # file name length
         byte_size(name)::little-size(16),
         # extra field length
-        IO.iodata_length([extra_field, encryption_extra_field])::little-size(16)
+        IO.iodata_length(final_extra_field)::little-size(16)
       >>,
       name,
-      [extra_field, encryption_extra_field]
+      final_extra_field
     ]
   end
 
@@ -99,11 +99,11 @@ defmodule Zstream.Protocol do
 
     encryption_coder = get_encryption_coder(options)
 
-    encryption_extra_field =
+    final_extra_field =
       if encryption_coder && function_exported?(encryption_coder, :extra_field_data, 1) do
-        encryption_coder.extra_field_data(options)
+        [extra_field, encryption_coder.extra_field_data(options)]
       else
-        <<>>
+        extra_field
       end
 
     version_needed_to_extract =
@@ -144,7 +144,7 @@ defmodule Zstream.Protocol do
         # file name length
         byte_size(entry.name)::little-size(16),
         # extra field length
-        IO.iodata_length([extra_field, encryption_extra_field])::little-size(16),
+        IO.iodata_length(final_extra_field)::little-size(16),
         # file comment length
         0::little-size(16),
         # disk number start
@@ -156,7 +156,7 @@ defmodule Zstream.Protocol do
       >>,
       # file name
       entry.name,
-      [extra_field, encryption_extra_field]
+      final_extra_field
     ]
   end
 

--- a/lib/zstream/zip.ex
+++ b/lib/zstream/zip.ex
@@ -165,11 +165,11 @@ defmodule Zstream.Zip do
 
   defp close_entry(state) do
     if state.coder do
-      {encrypted, _encryption_coder_state} =
+      {encrypted, encryption_coder_state} =
         state.coder.close(state.coder_state)
         |> state.encryption_coder.encode(state.encryption_coder_state)
 
-      encrypted = [encrypted, state.encryption_coder.close(state.encryption_coder_state)]
+      encrypted = [encrypted, state.encryption_coder.close(encryption_coder_state)]
       c_size = IO.iodata_length(encrypted)
       state = put_in(state.coder, nil)
       state = put_in(state.coder_state, nil)

--- a/test/zstream_test.exs
+++ b/test/zstream_test.exs
@@ -468,13 +468,12 @@ defmodule ZstreamTest do
     Enum.each(entries, fn entry ->
       extracted_path = Path.join(temp_dir, entry.name)
 
-      if File.exists?(extracted_path) do
-        extracted_content = File.read!(extracted_path)
-        original_content = as_binary(entry.stream)
+      assert File.exists?(extracted_path)
+      extracted_content = File.read!(extracted_path)
+      original_content = as_binary(entry.stream)
 
-        assert extracted_content == original_content,
-               "Content mismatch for #{entry.name}"
-      end
+      assert extracted_content == original_content,
+             "Content mismatch for #{entry.name}"
     end)
 
     File.rm_rf!(temp_dir)

--- a/test/zstream_test.exs
+++ b/test/zstream_test.exs
@@ -190,6 +190,55 @@ defmodule ZstreamTest do
     assert_memory()
   end
 
+  # only 256 is supported by 7z
+  test "aes 256 encryption" do
+    password = Base.encode64(:crypto.strong_rand_bytes(12))
+
+    verify_aes_password(
+      [
+        Zstream.entry("kafan", file("kafan.txt"),
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        ),
+        Zstream.entry("kafka_uncompressed", file("kafan.txt"),
+          coder: Zstream.Coder.Stored,
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        ),
+        Zstream.entry("कफ़न", file("kafan.txt"),
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        )
+      ],
+      password
+    )
+
+    # Test AES with empty files
+    verify_aes_password(
+      [
+        Zstream.entry("empty_file", [],
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        ),
+        Zstream.entry("empty_file_1", [],
+          coder: Zstream.Coder.Stored,
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        )
+      ],
+      password
+    )
+
+    # Test AES with larger files
+    verify_aes_password(
+      [
+        Zstream.entry("moby.txt", file("moby_dick.txt"),
+          coder: Zstream.Coder.Stored,
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        ),
+        Zstream.entry("deep/moby.txt", file("moby_dick.txt"),
+          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+        )
+      ],
+      password
+    )
+  end
+
   test "aes stream encryption" do
     big_file = Stream.repeatedly(&random_bytes/0) |> Stream.take(50)
 
@@ -364,5 +413,56 @@ defmodule ZstreamTest do
     total = (:erlang.memory() |> Keyword.fetch!(:total)) / (1024 * 1024)
     Logger.debug("Total memory: #{total}")
     assert total < 150
+  end
+
+  defp verify_aes_password(entries, password) do
+    verify_aes_password_with_options(entries, password)
+    verify_aes_password_with_options(entries, password, zip64: true)
+  end
+
+  defp verify_aes_password_with_options(entries, password, options \\ []) do
+    Temp.track!()
+    path = Temp.path!(%{suffix: ".zip"})
+
+    Zstream.zip(entries, options)
+    |> Stream.into(File.stream!(path))
+    |> Stream.run()
+
+    # Use 7zz to verify the AES encrypted archive
+    {response, exit_code} = System.cmd("7zz", ["l", path])
+    Logger.debug("7zz list output: #{response}")
+    assert exit_code == 0
+
+    # Test the archive integrity and password
+    {response, exit_code} = System.cmd("7zz", ["t", "-p#{password}", path])
+    Logger.debug("7zz test output: #{response}")
+    assert exit_code == 0
+
+    # Extract and verify file contents
+    temp_dir = Temp.mkdir!()
+
+    {response, exit_code} =
+      System.cmd("7zz", ["x", "-p#{password}", "-o#{temp_dir}", path, "-y"])
+
+    Logger.debug("7zz extract output: #{response}")
+    assert exit_code == 0
+
+    # Verify extracted file contents match original
+    entries = Enum.reject(entries, fn e -> String.ends_with?(e.name, "/") end)
+
+    Enum.each(entries, fn entry ->
+      extracted_path = Path.join(temp_dir, entry.name)
+
+      if File.exists?(extracted_path) do
+        extracted_content = File.read!(extracted_path)
+        original_content = as_binary(entry.stream)
+
+        assert extracted_content == original_content,
+               "Content mismatch for #{entry.name}"
+      end
+    end)
+
+    File.rm_rf!(temp_dir)
+    File.rm!(path)
   end
 end

--- a/test/zstream_test.exs
+++ b/test/zstream_test.exs
@@ -190,6 +190,22 @@ defmodule ZstreamTest do
     assert_memory()
   end
 
+  test "aes stream encryption" do
+    big_file = Stream.repeatedly(&random_bytes/0) |> Stream.take(50)
+
+    assert_memory()
+
+    # Test AES encryption with streaming
+    Zstream.zip([
+      Zstream.entry("big_file_aes", big_file,
+        encryption_coder: {Zstream.EncryptionCoder.AES, password: "test123", key_size: 256}
+      )
+    ])
+    |> Stream.run()
+
+    assert_memory()
+  end
+
   defmodule MockCoder do
     @behaviour Zstream.Coder
     def init(_opts), do: nil

--- a/test/zstream_test.exs
+++ b/test/zstream_test.exs
@@ -190,21 +190,24 @@ defmodule ZstreamTest do
     assert_memory()
   end
 
-  # only 256 is supported by 7z
+  # 7z only supports AES-256 encryption, so this test covers only the AES-256 case.
   test "aes 256 encryption" do
     password = Base.encode64(:crypto.strong_rand_bytes(12))
 
     verify_aes_password(
       [
         Zstream.entry("kafan", file("kafan.txt"),
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
         ),
         Zstream.entry("kafka_uncompressed", file("kafan.txt"),
           coder: Zstream.Coder.Stored,
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 2}
         ),
         Zstream.entry("कफ़न", file("kafan.txt"),
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
         )
       ],
       password
@@ -214,11 +217,13 @@ defmodule ZstreamTest do
     verify_aes_password(
       [
         Zstream.entry("empty_file", [],
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
         ),
         Zstream.entry("empty_file_1", [],
           coder: Zstream.Coder.Stored,
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 2}
         )
       ],
       password
@@ -229,10 +234,12 @@ defmodule ZstreamTest do
       [
         Zstream.entry("moby.txt", file("moby_dick.txt"),
           coder: Zstream.Coder.Stored,
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
         ),
         Zstream.entry("deep/moby.txt", file("moby_dick.txt"),
-          encryption_coder: {Zstream.EncryptionCoder.AES, password: password, key_size: 256}
+          encryption_coder:
+            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 2}
         )
       ],
       password

--- a/test/zstream_test.exs
+++ b/test/zstream_test.exs
@@ -190,60 +190,68 @@ defmodule ZstreamTest do
     assert_memory()
   end
 
-  # 7z only supports AES-256 encryption, so this test covers only the AES-256 case.
-  test "aes 256 encryption" do
-    password = Base.encode64(:crypto.strong_rand_bytes(12))
+  for ae_version <- [1, 2], key_size <- [256, 192, 128] do
+    test "aes key_size: #{key_size}, ae_version: #{ae_version} encryption" do
+      password = Base.encode64(:crypto.strong_rand_bytes(12))
 
-    verify_aes_password(
-      [
-        Zstream.entry("kafan", file("kafan.txt"),
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
-        ),
-        Zstream.entry("kafka_uncompressed", file("kafan.txt"),
-          coder: Zstream.Coder.Stored,
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 2}
-        ),
-        Zstream.entry("कफ़न", file("kafan.txt"),
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
-        )
-      ],
-      password
-    )
+      verify_aes_password(
+        [
+          Zstream.entry("kafan", file("kafan.txt"),
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          ),
+          Zstream.entry("kafka_uncompressed", file("kafan.txt"),
+            coder: Zstream.Coder.Stored,
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          ),
+          Zstream.entry("कफ़न", file("kafan.txt"),
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          )
+        ],
+        password
+      )
 
-    # Test AES with empty files
-    verify_aes_password(
-      [
-        Zstream.entry("empty_file", [],
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
-        ),
-        Zstream.entry("empty_file_1", [],
-          coder: Zstream.Coder.Stored,
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 2}
-        )
-      ],
-      password
-    )
+      # Test AES with empty files
+      verify_aes_password(
+        [
+          Zstream.entry("empty_file", [],
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          ),
+          Zstream.entry("empty_file_1", [],
+            coder: Zstream.Coder.Stored,
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          )
+        ],
+        password
+      )
 
-    # Test AES with larger files
-    verify_aes_password(
-      [
-        Zstream.entry("moby.txt", file("moby_dick.txt"),
-          coder: Zstream.Coder.Stored,
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 1}
-        ),
-        Zstream.entry("deep/moby.txt", file("moby_dick.txt"),
-          encryption_coder:
-            {Zstream.EncryptionCoder.AES, password: password, key_size: 256, ae_version: 2}
-        )
-      ],
-      password
-    )
+      # Test AES with larger files
+      verify_aes_password(
+        [
+          Zstream.entry("moby.txt", file("moby_dick.txt"),
+            coder: Zstream.Coder.Stored,
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          ),
+          Zstream.entry("deep/moby.txt", file("moby_dick.txt"),
+            encryption_coder:
+              {Zstream.EncryptionCoder.AES,
+               password: password, key_size: unquote(key_size), ae_version: unquote(ae_version)}
+          )
+        ],
+        password
+      )
+    end
   end
 
   test "aes stream encryption" do


### PR DESCRIPTION
This PR adds an initial implementation of WinZip-style AES encryption (spec here: https://www.winzip.com/en/support/aes-encryption). I’ve only done quick manual tests so far—macOS Archive Utility and the 7z CLI—because our current test tools don’t understand the WinZip AES extras yet.

If the maintainers are on board with this feature, I’d love any ideas for beefing up the test coverage.